### PR TITLE
Use reflection to pass formatter constructor args

### DIFF
--- a/app/code/community/Aleron75/Magemonolog/Model/Logwriter.php
+++ b/app/code/community/Aleron75/Magemonolog/Model/Logwriter.php
@@ -56,9 +56,8 @@ class Aleron75_Magemonolog_Model_Logwriter
                 if (array_key_exists('formatter', $handlerValues)
                     && array_key_exists('class', $handlerValues['formatter']))
                 {
-                    $class = '\\Monolog\Formatter\\'.$handlerValues['formatter']['class'];
-                    $args = $handlerValues['formatter']['args'];
-                    $formatter = new $class($args);
+                    $class = new ReflectionClass('\\Monolog\Formatter\\'.$handlerValues['formatter']['class']);
+                    $formatter = $class->newInstanceArgs($handlerValues['formatter']['args']);
                     $handlerWrapper->setFormatter($formatter);
                 }
 


### PR DESCRIPTION
Currently, formatter constructor args are passed as a single array, rather than as individual arguments.  This fixes that.
